### PR TITLE
make errors struct public

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -146,7 +146,7 @@ func (c *Client) do(ctx context.Context, op operationType, v interface{}, variab
 	}
 	var out struct {
 		Data   *json.RawMessage
-		Errors errors
+		Errors Errors
 		//Extensions interface{} // Unused.
 	}
 	err = json.NewDecoder(resp.Body).Decode(&out)
@@ -167,20 +167,21 @@ func (c *Client) do(ctx context.Context, op operationType, v interface{}, variab
 	return nil
 }
 
-// errors represents the "errors" array in a response from a GraphQL server.
+// Errors represents the "errors" array in a response from a GraphQL server.
 // If returned via error interface, the slice is expected to contain at least 1 element.
 //
 // Specification: https://facebook.github.io/graphql/#sec-Errors.
-type errors []struct {
+type Errors []struct {
 	Message   string
 	Locations []struct {
 		Line   int
 		Column int
 	}
+	Extensions interface{}
 }
 
 // Error implements error interface.
-func (e errors) Error() string {
+func (e Errors) Error() string {
 	return e[0].Message
 }
 

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -34,7 +34,11 @@ func TestClient_Query_partialDataWithErrorResponse(t *testing.T) {
 							"line": 10,
 							"column": 4
 						}
-					]
+					],
+					"extensions": {
+						"name": "ExtensionName",
+						"code": "EXTENSION_CODE"
+					}
 				}
 			]
 		}`)
@@ -55,6 +59,13 @@ func TestClient_Query_partialDataWithErrorResponse(t *testing.T) {
 	}
 	if got, want := err.Error(), "Could not resolve to a node with the global id of 'NotExist'"; got != want {
 		t.Errorf("got error: %v, want: %v", got, want)
+	}
+	errValue, ok := err.(graphql.Errors)
+	if !ok {
+		t.Errorf("got wrong error type: %T, want: graphql.Errors", err)
+	}
+	if errValue[0].Extensions == nil {
+		t.Errorf("got nil extensions, want non-nil")
 	}
 	if q.Node1 == nil || q.Node1.ID != "MDEyOklzc3VlQ29tbWVudDE2OTQwNzk0Ng==" {
 		t.Errorf("got wrong q.Node1: %v", q.Node1)


### PR DESCRIPTION
The main purpose of this PR is for the consumer to be able to obtain error information. Such error information, depending on the standard, is usually contained within the `Extensions` field of the error. We can just decode and expose such field as an `interface{}`, which will usually contain a `map[string]interface{}`, but this is for the consumer to deal with.
The main issue with exposing is backwards-compatibility, but since this is such a general error structure I don't think there's much of a problem.